### PR TITLE
fix: 9-stellige Postnummer

### DIFF
--- a/barcode-generator.js
+++ b/barcode-generator.js
@@ -16,8 +16,8 @@ function berechnen() {
 		return false;
 	}
 	
-	if (postnummer.toString().split('').length != 8){
-		alert("Postnummer muss genau 8 Ziffern haben!");
+	if (postnummer.toString().split('').length != 8 && postnummer.toString().split('').length != 9){
+		alert("Postnummer muss genau 8 oder 9 Ziffern haben!");
 		document.Entry.number.focus();
 		document.getElementById('number').style.color="red";
 		result = false;
@@ -25,7 +25,7 @@ function berechnen() {
   
 	barcodenummer = postnummer *= 631;
 	pruefziffer = luhn_calculate(barcodenummer); 
-	barcode = "3000" + barcodenummer + pruefziffer;
+	barcode = 3000000000000000 + barcodenummer * 10 + pruefziffer;
 
 	JsBarcode("#dhl-barcode", barcode);
 	}

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
 		<h3 style="text-align: center;">by <a href='https://pratt.de'>Dominic Pratt</a></h3>
 		<P>
 		<FORM NAME="formular">  
-		Postnummer (8-stellig): 
+		Postnummer (8 oder 9-stellig): 
 		
 		<INPUT TYPE="text" NAME="postnr" VALUE="" SIZE="8";>  
 		


### PR DESCRIPTION
Es gibt mittlerweile 9-stellige Postnummern.

Die Berechnung von `barcode` habe ich von string-concat auf integer-addition 
umgestellt, dabei das Stellenwertsystem genutzt.

Erfolgreiche Praxistests sind noch ausständig.